### PR TITLE
Refactoring on audio components

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,6 @@
 export * from './command.model';
 export * from './providers.model';
 export * from './soundcloud.model';
+export * from './stream-provider.model';
 export * from './track.model';
 export * from './youtube.model';

--- a/src/models/stream-provider.model.ts
+++ b/src/models/stream-provider.model.ts
@@ -1,0 +1,6 @@
+import { Readable } from 'stream';
+
+export interface StreamProvider {
+  stream?: Readable;
+  arbitraryURL?: string;
+}

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -163,7 +163,7 @@ function _playArbitraryInput(
  */
 function _onTrackEnd(reason: string, message: Discord.Message): void {
   const guildVoiceConnection = message.client.voiceConnections.get(message.guild.id);
-  const guildQueue = queue.getQueue(message);
+  const guildQueue = queue.removeFirstTrack(message);
 
   if (guildQueue.length > 0) {
     playTrack(guildQueue[0].initiator, guildQueue);

--- a/src/providers/handler.ts
+++ b/src/providers/handler.ts
@@ -16,7 +16,7 @@ const debug = Debug('streamer:handler');
  * @param provider provider of the url
  * @param track track object
  */
-export function handleStreamProvider(provider: models.providers, track: models.Track): { stream?: Readable, arbitraryURL?: string } {
+export function handleStreamProvider(provider: models.providers, track: models.Track): models.StreamProvider {
   switch (provider) {
     case 'youtube':
       return {


### PR DESCRIPTION
- Add `StreamProvider` model.
- Split `playArbitraryInput` and `playStream` calls into their own functions.
- Add `_onTrackEnd` private function to handle `on#end` event from `Discord.StreamDispatcher`.