### PR TITLE
Refactoring on providers

### DIFF
--- a/src/providers/handler.ts
+++ b/src/providers/handler.ts
@@ -41,36 +41,32 @@ export function handleStreamProvider(provider: models.providers, track: models.T
  * @param message the discord message that initiated this
  */
 export function handleProvider(provider: models.providers, query: string, message: Discord.Message): Promise<void | models.Track[]> {
-  return switchFetchMetadataProvider(provider, query, message)
+  return _switchFetchMetadataProvider(provider, query, message)
     .then((response) => {
+      // This means we haven't found any track
       if (response.length <= 0) {
         message.channel.send('Your track haven\'t been queued, there was an unexpected error, try again or something else');
         debug('promise resolved but no track added with query: %s with provider %s', query, provider);
       }
 
+      // This means we have a single-track
       if (response.length === 1) {
         const track = response[0];
 
-        if (!track) {
-          debug('was expecting a track at the first position of the array but got nothing: %O', response);
-          message.channel.send('There was an unexpected error, please try again or something else');
-        } else {
-          // For some weird reasons, discord.js add a strange symbol with interpolated strings
-          const richEmbed = utils.generateRichEmbed('Queued a new track', message.client)
-            .addField(track.title, utils.secondsToHHMMSS(track.duration) + ' — Added by ' + track.initiator.author.username)
-            .setThumbnail(track.thumbnailURL)
-            .setURL(track.url);
+        // For some weird reasons, discord.js add a strange symbol with interpolated strings
+        const richEmbed = utils.generateRichEmbed('Queued a new track', message.client)
+          .addField(track.title, _formatTrackAddedMessage(track.duration, track.initiator))
+          .setThumbnail(track.thumbnailURL)
+          .setURL(track.url);
 
-          debug('handled a single track from provider: %s with query/url: %s', provider, track.url);
-          message.channel.send(richEmbed);
-        }
+        debug('handled a single track from provider: %s with query/url: %s', provider, track.url);
+        message.channel.send(richEmbed);
       }
 
-      // This means we are trying to import a playlist, make sure we really
-      // want to import it in the queue by creating a reaction collector
+      // This means we are trying to import a playlist
       if (response.length > 1) {
         const richEmbed = utils.generateRichEmbed('Queued a new playlist', message.client)
-          .addField(`Added ${response.length} tracks into the queue`, 'If this is an error, you can clear the queue');
+          .setDescription(`Added ${response.length} tracks into the queue`);
 
         debug('handled an array of tracks from a playlist form provider: %s', provider);
         message.channel.send(richEmbed);
@@ -92,7 +88,7 @@ export function handleProvider(provider: models.providers, query: string, messag
  * @param query the query could be an url or a search query
  * @param message the discord message that initiated this
  */
-function switchFetchMetadataProvider(provider: models.providers, query: string, message: Discord.Message): Promise<models.Track[]> {
+function _switchFetchMetadataProvider(provider: models.providers, query: string, message: Discord.Message): Promise<models.Track[]> {
   switch (provider) {
     case 'youtube':
       return youtube.fetchHandler(query, message);
@@ -102,4 +98,18 @@ function switchFetchMetadataProvider(provider: models.providers, query: string, 
       return soundcloud.fetchHandler(query, message);
       break;
   }
+}
+
+/**
+ * Returns the track-added message to be used in a rich-embed. This function
+ * doesn't use ES6 template strings because of an incompatibility with
+ * `discord.js` where it adds a strange symbol on the string.
+ *
+ * @param duration duration of the track in ms
+ * @param message the discord message that initiated this
+ */
+function _formatTrackAddedMessage(duration: string, message: Discord.Message): string {
+  const formattedTime = utils.secondsToHHMMSS(duration);
+
+  return formattedTime + ' - Added by ' + message.author.username;
 }

--- a/src/providers/soundcloud.ts
+++ b/src/providers/soundcloud.ts
@@ -18,7 +18,6 @@ export function fetchHandler(query: string, message: Discord.Message): Promise<m
         return response.tracks.map((track) => mapTrackToTrack(track, message));
       }
 
-      // debug('the url have been resolved but the response didn\'t matched any criteria to map-track: %O', response);
       return [];
     });
 }


### PR DESCRIPTION
- Rename `_switchFetchMetadataProvider` since it's a local function.
- Add a bit more comments on how `handleProvider` works.
- Split `_formatTrackAddedMessage` local function helper for rich-embeds.