### PR TITLE
Update lerna to the latest version 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "postinstall": "yarn run bootstrap"
   },
   "devDependencies": {
-    "lerna": "^3.6.0"
+    "lerna": "^3.10.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,48 +2,48 @@
 # yarn lockfile v1
 
 
-"@lerna/add@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.8.2.tgz#4e6ac25c6df7e4422e56f719b800750031c30b5f"
-  integrity sha512-P9U5fzvrINVcslfn2CoMoRH0k+skwNTEsBTYkqjRf+ZYaaM3PvKzXvnonMfPSLBgAK3bBMnzinfb3USJnStx2w==
+"@lerna/add@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.10.2.tgz#586a2db4f3e53c47390c9cd3c59a1925f75760f1"
+  integrity sha512-mEgF6lzIIvH8XisznANmRIpFDIUA9FiEDkR7N86tWuKJoqv/6Q72MaUT+QlV5G9tkgKgsVZ5T/Jaxudr6ZlTzA==
   dependencies:
-    "@lerna/bootstrap" "^3.8.2"
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/npm-conf" "^3.7.0"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/bootstrap" "3.10.2"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/npm-conf" "3.7.0"
+    "@lerna/validation-error" "3.6.0"
     dedent "^0.7.0"
     libnpm "^2.0.1"
     p-map "^1.2.0"
     semver "^5.5.0"
 
-"@lerna/batch-packages@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.6.0.tgz#66cf3ce914bbd0532071c58d5f0c913315054158"
-  integrity sha512-khG15B+EFLH3Oms6A6WsMAy54DrnKIhEAm6CCATN2BKnBkNgitYjLN2vKBzlR2LfQpTkgub67QKIJkMFQcK1Sg==
+"@lerna/batch-packages@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.10.0.tgz#64635b522d6277b98ae7bfe23f9300dca44d02b8"
+  integrity sha512-ERvnpmmfV8H+3B+9FmHqmzfgz0xVe3ktW/e4WZZXYMGpqSGToILZlai4PsBrW5gUtnXA77LSskME+aRdkZaKsQ==
   dependencies:
-    "@lerna/package-graph" "^3.6.0"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/package-graph" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
     libnpm "^2.0.1"
 
-"@lerna/bootstrap@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.8.2.tgz#9a7d4d6f77e83bbb6131db64a50eebd7242ce153"
-  integrity sha512-/MT2krnth21mI2t3S6M1FJ4MUt+h+ycwcSfHhDMsgqfPqtb6y7awWlAFjHzgWXxf1LUOStkIOoGsJGNsxjiXWQ==
+"@lerna/bootstrap@3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.10.2.tgz#a45efd4d74ef4a3b1ae1b95023a8b187f49f2c88"
+  integrity sha512-6ux3eApTvRaok0DbAtVgv2WECYDAqqz+2zUiamR7stYHai78kO/95+WJxjHWytch5tZOb2sFIjNu6vvg7AjYEw==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/has-npm-version" "^3.3.0"
-    "@lerna/npm-install" "^3.8.2"
-    "@lerna/package-graph" "^3.6.0"
-    "@lerna/pulse-till-done" "^3.7.1"
-    "@lerna/rimraf-dir" "^3.6.0"
-    "@lerna/run-lifecycle" "^3.8.2"
-    "@lerna/run-parallel-batches" "^3.0.0"
-    "@lerna/symlink-binary" "^3.7.2"
-    "@lerna/symlink-dependencies" "^3.8.1"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/batch-packages" "3.10.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/has-npm-version" "3.10.0"
+    "@lerna/npm-install" "3.10.0"
+    "@lerna/package-graph" "3.10.0"
+    "@lerna/pulse-till-done" "3.7.1"
+    "@lerna/rimraf-dir" "3.10.0"
+    "@lerna/run-lifecycle" "3.10.0"
+    "@lerna/run-parallel-batches" "3.0.0"
+    "@lerna/symlink-binary" "3.10.0"
+    "@lerna/symlink-dependencies" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
     dedent "^0.7.0"
     get-port "^3.2.0"
     libnpm "^2.0.1"
@@ -55,26 +55,26 @@
     read-package-tree "^5.1.6"
     semver "^5.5.0"
 
-"@lerna/changed@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.8.2.tgz#61c40a59ab33488cd920f5406d2ff2023dc78e1d"
-  integrity sha512-NMxLftHcNVZH+kdL9qylD4c/ZYljQ7YOQdgrc97ds23dk11UhLVAkbbpRVU5DE/s+bqo03zROVHPEYT+ELQjWg==
+"@lerna/changed@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.10.1.tgz#efb110a2eb528f335549edf84e652f8468a26493"
+  integrity sha512-GlAkOUhQQw6Xaf9HuB1Vwrf//ODZ9S45ZjoDFZWwf+13QkIG3ywNvg7+Cfq/3wdlvarIGc30MQEehku0mazVoA==
   dependencies:
-    "@lerna/collect-updates" "^3.8.1"
-    "@lerna/command" "^3.8.1"
-    "@lerna/listable" "^3.6.0"
-    "@lerna/output" "^3.6.0"
-    "@lerna/version" "^3.8.2"
+    "@lerna/collect-updates" "3.10.1"
+    "@lerna/command" "3.10.0"
+    "@lerna/listable" "3.10.0"
+    "@lerna/output" "3.6.0"
+    "@lerna/version" "3.10.1"
 
-"@lerna/check-working-tree@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.8.1.tgz#bda0719f3a3ceaed976b08f57b054af6a0acf295"
-  integrity sha512-UJqyvFr3+MTDo31fVjJlV/eshmQg8u0vpQcY95Vs00B99QxzLoICSGpNdldhSBnOIpOlq6tm5H/2hflc5hANew==
+"@lerna/check-working-tree@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.10.0.tgz#5ed9f2c5c942bee92afcd8cb5361be44ed0251e3"
+  integrity sha512-NdIPhDgEtGHfeGjB9F0oAoPLywgMpjnJhLLwTNQkelDHo2xNAVpG8kV+A2UJ+cU5UXCZA4RZFxKNmw86rO+Drw==
   dependencies:
-    "@lerna/describe-ref" "^3.8.1"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/describe-ref" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
 
-"@lerna/child-process@^3.3.0":
+"@lerna/child-process@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.3.0.tgz#71184a763105b6c8ece27f43f166498d90fe680f"
   integrity sha512-q2d/OPlNX/cBXB6Iz1932RFzOmOHq6ZzPjqebkINNaTojHWuuRpvJJY4Uz3NGpJ3kEtPDvBemkZqUBTSO5wb1g==
@@ -83,63 +83,63 @@
     execa "^1.0.0"
     strong-log-transformer "^2.0.0"
 
-"@lerna/clean@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.8.1.tgz#40df71a3481b369266fd467bafd481e79390f100"
-  integrity sha512-+jxuiKdvau3tlhiMq1cQMzzdr/4b95q4Cmpt8BD5ivrEpD+X3pCJGjjMxybpi5sZzR/XWlfJn9vn9mnFpyTrTA==
+"@lerna/clean@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.10.1.tgz#abf0cb3b19935d5931ad4c46c7cab79503be3f0e"
+  integrity sha512-eYSNSD4xD//OIDe0r4r/HhEMEXriIuKqp4BMDhrO7pJmYhk7FvznJUSc4jc85wdA4Y0ooqSs9gF/w2lgLGgUxw==
   dependencies:
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/prompt" "^3.6.0"
-    "@lerna/pulse-till-done" "^3.7.1"
-    "@lerna/rimraf-dir" "^3.6.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/prompt" "3.6.0"
+    "@lerna/pulse-till-done" "3.7.1"
+    "@lerna/rimraf-dir" "3.10.0"
     p-map "^1.2.0"
     p-map-series "^1.0.0"
     p-waterfall "^1.0.0"
 
-"@lerna/cli@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.6.0.tgz#f86c16a095bd5506e927b9385ddefb13c605b1df"
-  integrity sha512-FGCx7XOLpqmU5eFOlo0Lt0hRZraxSUTEWM0bce0p+HNpOxBc91o6d2tenW1azPYFP9HzsMQey1NBtU0ofJJeog==
+"@lerna/cli@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.10.0.tgz#48ab57a450eaec0401db082319f1bc11939b6d5e"
+  integrity sha512-OTO8GlD6Rf298hxml3/Y3OE8yMDuW3NNqumbroiUb/KdkrnyjZl5F6aSMXJEySq+OSoBboZJMwj2IWglc/7fuw==
   dependencies:
-    "@lerna/global-options" "^3.1.3"
+    "@lerna/global-options" "3.1.3"
     dedent "^0.7.0"
     libnpm "^2.0.1"
     yargs "^12.0.1"
 
-"@lerna/collect-updates@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.8.1.tgz#e227efe9955b56b258baf7e8f853f779d40556a7"
-  integrity sha512-1ULd1FBX8j8XGe166CUx+PkNeBJrbauI6Ux9+NiVrpeyE5rF6hzrowRyaptE9n5jzAl0WtTTIP1MsdrVG7BvAA==
+"@lerna/collect-updates@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.10.1.tgz#3ad60aa31826c0c0cfdf8bf41e58e6c5c86aeb3a"
+  integrity sha512-vb0wEJ8k63G+2CR/ud1WeVHNJ21Fs6Ew6lbdGZXnF4ZvaFWxWJZpoHeWwzjhMdJ75QdTzUaIhTG1hnH9faQNMw==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/describe-ref" "^3.8.1"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/describe-ref" "3.10.0"
     libnpm "^2.0.1"
     minimatch "^3.0.4"
     slash "^1.0.0"
 
-"@lerna/command@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.8.1.tgz#ec5b2f7ff1b2ad7491179dfc8b6708d4fedf4c6f"
-  integrity sha512-AWC1ziiSCJikuviBcQHOc9qTqGS/KwG9cy4wbk65Zxmfy373/JJEt0bg0bfo48reZ2HiJu0mBXLitd3brXpdIw==
+"@lerna/command@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.10.0.tgz#d1229dc8efa5b6f793492bcab8f9e514175826b6"
+  integrity sha512-TTtCDQ5+bDdA/RnBuDtkfqzUV8Mr61KBHxEZL8YLAmHZtY/HsnNpZzbAZ0STPxcFB96dhxVWbRDGP+yBgRfemQ==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/package-graph" "^3.6.0"
-    "@lerna/project" "^3.7.2"
-    "@lerna/validation-error" "^3.6.0"
-    "@lerna/write-log-file" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/package-graph" "3.10.0"
+    "@lerna/project" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
+    "@lerna/write-log-file" "3.6.0"
     dedent "^0.7.0"
     execa "^1.0.0"
     is-ci "^1.0.10"
     libnpm "^2.0.1"
     lodash "^4.17.5"
 
-"@lerna/conventional-commits@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.6.0.tgz#b44edb60e23453d8b15dcd1accf28c421581a8c5"
-  integrity sha512-KkY3wd7w/tj76EEIhTMYZlSBk/5WkT2NA9Gr/EuSwKV70PYyVA55l1OGlikBUAnuqIjwyfw9x3y+OcbYI4aNEg==
+"@lerna/conventional-commits@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.10.0.tgz#284cc16bd3c387f841ff6bec42bcadaa2d13d8e4"
+  integrity sha512-8FvO0eR8g/tEgkb6eRVYaD39TsqMKsOXp17EV48jciciEqcrF/d1Ypu6ilK1GDp6R/1m2mbjt/b52a/qrO+xaw==
   dependencies:
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/validation-error" "3.6.0"
     conventional-changelog-angular "^5.0.2"
     conventional-changelog-core "^3.1.5"
     conventional-recommended-bump "^4.0.4"
@@ -148,7 +148,7 @@
     libnpm "^2.0.1"
     semver "^5.5.0"
 
-"@lerna/create-symlink@^3.6.0":
+"@lerna/create-symlink@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/create-symlink/-/create-symlink-3.6.0.tgz#f1815cde2fc9d8d2315dfea44ee880f2f1bc65f1"
   integrity sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==
@@ -157,15 +157,15 @@
     fs-extra "^7.0.0"
     libnpm "^2.0.1"
 
-"@lerna/create@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.8.1.tgz#f8f6e282786c60caeb01306f2929645b77e965f2"
-  integrity sha512-+mUkK9MEwTa8w69+yf5WhGF7csxn7wJRmsBe99J7QklamOSZXTLt4O5AeBtaYKFdJ9Tf5D+oxENMYLd2EaJNSw==
+"@lerna/create@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.10.0.tgz#67293ca242ed5ec180469c34d0f073c297be6799"
+  integrity sha512-1EQbhyGx/J+gwlxFPecpmrztyEfBRm/sNei95UJlJWLuturSv2Ax2nCa49tcerbPlYhhlJ6lyintukL5STOzdg==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/npm-conf" "^3.7.0"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/npm-conf" "3.7.0"
+    "@lerna/validation-error" "3.6.0"
     camelcase "^4.1.0"
     dedent "^0.7.0"
     fs-extra "^7.0.0"
@@ -180,62 +180,62 @@
     validate-npm-package-name "^3.0.0"
     whatwg-url "^7.0.0"
 
-"@lerna/describe-ref@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.8.1.tgz#b99ef6f8aa58fa9389af1e03beaa716cc6cb506d"
-  integrity sha512-EPXFiZbWG0KiaDM+BT3RZahy5gwrTVyKDv8HmPkGhu2h4pr34tzsSMmYmJ8I0dLeu4IpP/G/OIBa6DkYWisiZw==
+"@lerna/describe-ref@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.10.0.tgz#266380feece6013ab9674f52bd35bf0be5b0460d"
+  integrity sha512-fouh3FQS07QxJJp/mW8LkGnH0xMRAzpBlejtZaiRwfDkW2kd6EuHaj8I/2/p21Wsprcvuu4dqmyia2YS1xFb/w==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
+    "@lerna/child-process" "3.3.0"
     libnpm "^2.0.1"
 
-"@lerna/diff@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.8.1.tgz#739836a7faf6d08e820a936aa765fd45e805371c"
-  integrity sha512-FrQ2c7AULUs4eYwLE5adw6YObRdS8EgCbq5dE/sLrvnqODniM2hRnMf/zsFl4R8wf9PIs5tFXdyTdMVsQfwZGg==
+"@lerna/diff@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.10.0.tgz#343403a6700063e5b264c013ee500b76c3bcf156"
+  integrity sha512-MU6P9uAND+dZ15Cm4onJakEYMC6xXZApLuPpWJf0kZtVoF2Feoo3mvQASdb17fe0jvvmWDS0RLCzq9Zhzrgm0A==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
     libnpm "^2.0.1"
 
-"@lerna/exec@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.8.1.tgz#a73c812cb7bea6fccef9d0d8e940e395f235af17"
-  integrity sha512-v+AAxkq19UdTfsO0aOfmAvQs9GnDpy5TyP1q4NVOZCotLOfVnFQ16QfzVCBA4hR3a6puugs3lmaOlQnMmDoDFQ==
+"@lerna/exec@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.10.1.tgz#3047b04418060d109724ab4468abea22e8ffa992"
+  integrity sha512-MM5/OMP4FrVH4PIlG+3xk3jpKq+trgu/eAPttaYZBHAumCOjrDVYdyk5O68+YLz+uLkM31ixTmsiAP9f77HTsg==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/run-parallel-batches" "^3.0.0"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/batch-packages" "3.10.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/run-parallel-batches" "3.0.0"
+    "@lerna/validation-error" "3.6.0"
 
-"@lerna/filter-options@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.8.1.tgz#8c9708d60681383051d90a06eaa292dddd1d16b4"
-  integrity sha512-ty4Pl+vZjPSc7jc4nhK/4YYGKpLOhcGHLw6Zu71D4V3DJW/ZDHm/veRIApmhddL7+6y9G+ZGnGYYh/8RFyT6hA==
+"@lerna/filter-options@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.10.1.tgz#12ecda84577e50d508a8cf696df7e20abbc2304d"
+  integrity sha512-34q7P0/AA+omVk9uwv99i+4qmj5uGuj383RzqIcK8JDYL0JSzlmW0+c4IkxunCfRrWft8OFhSwZdOOmXtDSDYg==
   dependencies:
-    "@lerna/collect-updates" "^3.8.1"
-    "@lerna/filter-packages" "^3.6.0"
+    "@lerna/collect-updates" "3.10.1"
+    "@lerna/filter-packages" "3.10.0"
     dedent "^0.7.0"
 
-"@lerna/filter-packages@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.6.0.tgz#4cad0bd5b32974b546b845283ac870d62ea4646a"
-  integrity sha512-O/nIENV3LOqp/TiUIw3Ir6L/wUGFDeYBdJsJTQDlTAyHZsgYA1OIn9FvlW8nqBu1bNLzoBVHXh3c5azx1kE+Hg==
+"@lerna/filter-packages@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.10.0.tgz#75f9a08184fc4046da2057e0218253cd6f493f05"
+  integrity sha512-3Acdj+jbany6LnQSuImU4ttcK5ULHSVug8Gh/EvwTewKCDpHAuoI3eyuzZOnSBdMvDOjE03uIESQK0dNNsn6Ow==
   dependencies:
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/validation-error" "3.6.0"
     libnpm "^2.0.1"
     multimatch "^2.1.0"
 
-"@lerna/get-npm-exec-opts@^3.6.0":
+"@lerna/get-npm-exec-opts@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz#ea595eb28d1f34ba61a92ee8391f374282b4b76e"
   integrity sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==
   dependencies:
     libnpm "^2.0.1"
 
-"@lerna/get-packed@^3.7.0":
+"@lerna/get-packed@3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@lerna/get-packed/-/get-packed-3.7.0.tgz#549c7738f7be5e3b1433e82ed9cda9123bcd1ed5"
   integrity sha512-yuFtjsUZIHjeIvIYQ/QuytC+FQcHwo3peB+yGBST2uWCLUCR5rx6knoQcPzbxdFDCuUb5IFccFGd3B1fHFg3RQ==
@@ -244,75 +244,75 @@
     ssri "^6.0.1"
     tar "^4.4.8"
 
-"@lerna/global-options@^3.1.3":
+"@lerna/global-options@3.1.3":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.1.3.tgz#cf85e24655a91d04d4efc9a80c1f83fc768d08ae"
   integrity sha512-LVeZU/Zgc0XkHdGMRYn+EmHfDmmYNwYRv3ta59iCVFXLVp7FRFWF7oB1ss/WRa9x/pYU0o6L8as/5DomLUGASA==
 
-"@lerna/has-npm-version@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.3.0.tgz#8a73c2c437a0e1e68a19ccbd0dd3c014d4d39135"
-  integrity sha512-GX7omRep1eBRZHgjZLRw3MpBJSdA5gPZFz95P7rxhpvsiG384Tdrr/cKFMhm0A09yq27Tk/nuYTaZIj7HsVE6g==
+"@lerna/has-npm-version@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.10.0.tgz#d3a73c0fedd2f2e9c6fbe166c41809131dc939d2"
+  integrity sha512-N4RRYxGeivuaKgPDzrhkQOQs1Sg4tOnxnEe3akfqu1wDA4Ng5V6Y2uW3DbkAjFL3aNJhWF5Vbf7sBsGtfgDQ8w==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
+    "@lerna/child-process" "3.3.0"
     semver "^5.5.0"
 
-"@lerna/import@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.8.1.tgz#d6565c43d993f2827d1ef84c6bfb3a61ee563881"
-  integrity sha512-4GETPwbZOd7HuSDaqiAf6UENBLzmU2ICE7RXGoe5hIyCIYODx8q+/OSBYOdpV0hHbm/4IaKDa/k0rvCrI/dUFQ==
+"@lerna/import@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.10.0.tgz#701f47c2717bf47cdca0a31ed409ed6fbe973591"
+  integrity sha512-c8/s/ldaNVGuKnu600B3nbkwJTNElp1duJiZQ7EBChF+szbQBAiQUGNLvBbwClLBzVJhKTw6E4ku17HafQ4vqg==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/prompt" "^3.6.0"
-    "@lerna/pulse-till-done" "^3.7.1"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/prompt" "3.6.0"
+    "@lerna/pulse-till-done" "3.7.1"
+    "@lerna/validation-error" "3.6.0"
     dedent "^0.7.0"
     fs-extra "^7.0.0"
     p-map-series "^1.0.0"
 
-"@lerna/init@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.8.1.tgz#0c417573865253cbd87d40ccbec089fae9119f6b"
-  integrity sha512-pWS5EBaRr7kNr5uQSN06vd1kN2afIRJoYA4PEiD1Cs4Z9tPJYoDMEClPnss0sdh8O8RH3IzcDkN2gjzLn7oe/Q==
+"@lerna/init@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.10.0.tgz#073bd12dfeb222b920d848c05f840adcbc23ef63"
+  integrity sha512-+zU1A870OOOqy3MPLcEoicN6dnIGZv/q0aqCVRRfCHAICciaswuIvdX0uDJx0NrUe0sW40dzIllxuUA39nPqcw==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/command" "^3.8.1"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/command" "3.10.0"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
     write-json-file "^2.3.0"
 
-"@lerna/link@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.8.1.tgz#1c11b52843f8c4f2ebc8e13f98a28225e2fefca2"
-  integrity sha512-IKdnForLXk9XrR4i02ExfK//pQe94z0Q7TF9uSbjHk1JNLnUSzxRZ31WeuI5/ZZrhdHBJV1eDb6lJg7IRiXH5A==
+"@lerna/link@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.10.0.tgz#28b82197907f2622d154070a65fe92c9f67e075c"
+  integrity sha512-uZvLxTSekqV8Kx0zMPgcxpTWyRkjnqnUzRiff9HQtOq+gBBifX079jGT7X73CO5eXFzp2TkOJtI1KNL0BNoNtA==
   dependencies:
-    "@lerna/command" "^3.8.1"
-    "@lerna/package-graph" "^3.6.0"
-    "@lerna/symlink-dependencies" "^3.8.1"
+    "@lerna/command" "3.10.0"
+    "@lerna/package-graph" "3.10.0"
+    "@lerna/symlink-dependencies" "3.10.0"
     p-map "^1.2.0"
     slash "^1.0.0"
 
-"@lerna/list@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.8.1.tgz#ae7a148f4e6494278f96e9c909a30ef6362f1dab"
-  integrity sha512-2Eafq6tlbXmCMBCpKLlQRD27b2W2ygAc6X/jYJ9bZtKZ1ZzNBjp5TWIHQAvj3/vAAR1VhSrfL+rMHIaqzEAASg==
+"@lerna/list@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.10.1.tgz#09fdf4d394caa23e9fc32c2557c5de480ba0252a"
+  integrity sha512-y2VwTeJ8tcQ0dmJJNhloGfhmCBUG3RXafqNkUVUG/ItoJlfzVniQOMdIDlkre86ZtnQv9yrB2vFaC2Vg++PklQ==
   dependencies:
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/listable" "^3.6.0"
-    "@lerna/output" "^3.6.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/listable" "3.10.0"
+    "@lerna/output" "3.6.0"
 
-"@lerna/listable@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/listable/-/listable-3.6.0.tgz#25c9cc062ae0d3e78c53da30cdf9f011696ae48f"
-  integrity sha512-fz63+zlqrJ9KQxIiv0r7qtufM4DEinSayAuO8YJuooz+1ctIP7RvMEQNvYI/E9tDlUo9Q0de68b5HbKrpmA5rQ==
+"@lerna/listable@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/listable/-/listable-3.10.0.tgz#ac59671407725d662ed6d9234616c0fbbb0163f6"
+  integrity sha512-95EwogHBqJxrXOCkf3DAZQAzJes+I668Lg5BJDotfp9eZeJAbgGl6GPz5U+szPq0PrYfK+2kJv9xNXVnbfCZAw==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
+    "@lerna/batch-packages" "3.10.0"
     chalk "^2.3.1"
     columnify "^1.5.4"
 
-"@lerna/log-packed@^3.6.0":
+"@lerna/log-packed@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/log-packed/-/log-packed-3.6.0.tgz#bed96c2bdd47f076d9957d0c6069b2edc1518145"
   integrity sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==
@@ -322,7 +322,7 @@
     has-unicode "^2.0.1"
     libnpm "^2.0.1"
 
-"@lerna/npm-conf@^3.7.0":
+"@lerna/npm-conf@3.7.0":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.7.0.tgz#f101d4fdf07cefcf1161bcfaf3c0f105b420a450"
   integrity sha512-+WSMDfPKcKzMfqq283ydz9RRpOU6p9wfx0wy4hVSUY/6YUpsyuk8SShjcRtY8zTM5AOrxvFBuuV90H4YpZ5+Ng==
@@ -330,76 +330,76 @@
     config-chain "^1.1.11"
     pify "^3.0.0"
 
-"@lerna/npm-dist-tag@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.7.1.tgz#4f848320653162e3ee6dc283d9086beea896d675"
-  integrity sha512-caUfA1L6wFl/nvIkk4q7qbFHZSnF2P8zf3Xk7vJMolRybYbj+WT1gYb5C446qPIF75p7JtFu3C/AJzwzdbljCw==
+"@lerna/npm-dist-tag@3.8.5":
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.8.5.tgz#5ce22a72576badc8cb6baf85550043d63e66ea44"
+  integrity sha512-VO57yKTB4NC2LZuTd4w0LmlRpoFm/gejQ1gqqLGzSJuSZaBXmieElFovzl21S07cqiy7FNVdz75x7/a6WCZ6XA==
   dependencies:
     figgy-pudding "^3.5.1"
     libnpm "^2.0.1"
 
-"@lerna/npm-install@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.8.2.tgz#24c7271a62bd3ec03275cf0a1c5fbafef4955f42"
-  integrity sha512-A22IrhPy70Gm30rBYSPp/PDWjByvj6QdxqQh41HlNGOCzM5WCCSDXpfeoxzS0ow0d3WGJMraE2k1GFpOP6Hyxg==
+"@lerna/npm-install@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.10.0.tgz#fcd6688a3a2cd0e702a03c54c22eb7ae8b3dacb0"
+  integrity sha512-/6/XyLY9/4jaMPBOVYUr4wZxQURIfwoELY0qCQ8gZ5zv4cOiFiiCUxZ0i4fxqFtD7nJ084zq1DsZW0aH0CIWYw==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/get-npm-exec-opts" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/get-npm-exec-opts" "3.6.0"
     fs-extra "^7.0.0"
     libnpm "^2.0.1"
     signal-exit "^3.0.2"
     write-pkg "^3.1.0"
 
-"@lerna/npm-publish@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.8.2.tgz#5f2bc820894c73a77fc277135fba6e4ade7c24f5"
-  integrity sha512-0ZVEmD7vQs29mV35O/8q/eCvTVA4nu49Jpq5821TMMENa2CiBmQCWv/MqLaQlPCAdTx/kXHJMQ9kmhwrhks0Aw==
+"@lerna/npm-publish@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.10.0.tgz#3cf133602833cceeb1c06a77f3c345fac2ba0465"
+  integrity sha512-VceSHFISfZamuRhTx94HKjkoKjNiubw1iLzwHGhkCp4s6cHWwZ0vuE5eopdb61akpcEiavdSwRq0k0MNiiGMzg==
   dependencies:
-    "@lerna/run-lifecycle" "^3.8.2"
+    "@lerna/run-lifecycle" "3.10.0"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpm "^2.0.1"
 
-"@lerna/npm-run-script@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.6.0.tgz#4b97e6f571ae9fdabed21d5d4fc35a2b7e9d5267"
-  integrity sha512-6DRNFma30ex9r1a8mMDXziSRHf1/mo//hnvW1Zc1ctBh+7PU4I8n3A2ht/+742vtoTQH93Iqs3QSJl2KOLSsYg==
+"@lerna/npm-run-script@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.10.0.tgz#49a9204eddea136da15a8d8d9eba2c3175b77ddd"
+  integrity sha512-c21tBXLF1Wje4tx/Td9jKIMrlZo/8QQiyyadjdKpwyyo7orSMsVNXGyJwvZ4JVVDcwC3GPU6HQvkt63v7rcyaw==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/get-npm-exec-opts" "^3.6.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/get-npm-exec-opts" "3.6.0"
     libnpm "^2.0.1"
 
-"@lerna/output@^3.6.0":
+"@lerna/output@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/output/-/output-3.6.0.tgz#a69384bc685cf3b21aa1bfc697eb2b9db3333d0b"
   integrity sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==
   dependencies:
     libnpm "^2.0.1"
 
-"@lerna/pack-directory@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/pack-directory/-/pack-directory-3.8.2.tgz#5ffddce7781998195cffcbe51128c5a69dd3ca7a"
-  integrity sha512-sYXioixVw3L5r9O4bt+hnfPQ8jLn/PVOJVivQdpSlup+ZUiI5mmtjzAO3NOK/k8DZf8YrUx0Lm1+vzgnqu1tKw==
+"@lerna/pack-directory@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/pack-directory/-/pack-directory-3.10.0.tgz#4f09218d6a15e689dc579c47ce810e70fdec86a2"
+  integrity sha512-pcGO2BZRlQbRR5Xj+r4qIROT0Lvb7Ks1Z+MuaIAukEzRemAvWpjEYTyWeWxKHxzDsZ0eUpWGnm6WQTzI/TByQQ==
   dependencies:
-    "@lerna/get-packed" "^3.7.0"
-    "@lerna/package" "^3.7.2"
-    "@lerna/run-lifecycle" "^3.8.2"
+    "@lerna/get-packed" "3.7.0"
+    "@lerna/package" "3.7.2"
+    "@lerna/run-lifecycle" "3.10.0"
     figgy-pudding "^3.5.1"
     libnpm "^2.0.1"
     npm-packlist "^1.1.12"
     tar "^4.4.8"
     temp-write "^3.4.0"
 
-"@lerna/package-graph@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.6.0.tgz#d13e6e80d30e2e29226d335412997b9ddf646305"
-  integrity sha512-Xtldh3DTiC3cPDrs6OY5URiuRXGPMIN6uFKcx59rOu3TkqYRt346jRyX+hm85996Y/pboo3+JuQlonvuEP/9QQ==
+"@lerna/package-graph@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.10.0.tgz#e457900d52164b9640e6a425ce679f73afb49246"
+  integrity sha512-9LX8I8KxzCMjfNPWvN/CxHW51s89S3Mnx2EYsbo8c8Gh8I6InA6e+Xur6uuCyZ6/0LKqQ/cXwrP3J81A4nIDSQ==
   dependencies:
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/validation-error" "3.6.0"
     libnpm "^2.0.1"
     semver "^5.5.0"
 
-"@lerna/package@^3.7.2":
+"@lerna/package@3.7.2":
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/@lerna/package/-/package-3.7.2.tgz#03c69fd7fb965c372c8c969165a2f7d6dfe2dfcb"
   integrity sha512-8A5hN2CekM1a0Ix4VUO/g+REo+MsnXb8lnQ0bGjr1YGWzSL5NxYJ0Z9+0pwTfDpvRDYlFYO0rMVwBUW44b4dUw==
@@ -408,13 +408,13 @@
     load-json-file "^4.0.0"
     write-pkg "^3.1.0"
 
-"@lerna/project@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.7.2.tgz#02315e10b6de85289e9388c0e260d8f12d246c38"
-  integrity sha512-YNJw61G4YrnwW0P1NAR/bd/kfDdK+WPI5YH10AHsG1TXBFV9hBusjB7MROmobYbln7zNWJJ3PQmXtWv134aaRQ==
+"@lerna/project@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.10.0.tgz#98272bf2eb93e9b21850edae568d696bf7fdebda"
+  integrity sha512-9QRl8aGHuyU4zVEELQmNPnJTlS7XHqX7w9I9isCXdnilKc2R0MyvUs21lj6Yyt6xTuQnqD158TR9tbS4QufYQQ==
   dependencies:
-    "@lerna/package" "^3.7.2"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/package" "3.7.2"
+    "@lerna/validation-error" "3.6.0"
     cosmiconfig "^5.0.2"
     dedent "^0.7.0"
     dot-prop "^4.2.0"
@@ -426,7 +426,7 @@
     resolve-from "^4.0.0"
     write-json-file "^2.3.0"
 
-"@lerna/prompt@^3.6.0":
+"@lerna/prompt@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/prompt/-/prompt-3.6.0.tgz#b17cc464dec9d830619723e879dc747367378217"
   integrity sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==
@@ -434,29 +434,29 @@
     inquirer "^6.2.0"
     libnpm "^2.0.1"
 
-"@lerna/publish@^3.8.4":
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.8.4.tgz#5c24180a136aacbb7b5eb81dc9ca6a130ab4e56d"
-  integrity sha512-Bbz3Ne0UHiBqLrHAhB2+zitzYjgjIiydLmhLiuzhwbPgah7kP7nv9/HrXv927kjEY7EHd/+zqs/NuviJvKKb0g==
+"@lerna/publish@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.10.1.tgz#fe994503c0917730042c39a45121e3f3ca4a223f"
+  integrity sha512-wDWcXW/7n8M+cnVHM/Gcr8+p1GpN1cOmHFUa8ykVFAeVnAW/nDd7qAeg4pOsOR5uxCrpY9IuWQQVrip0BJwl1w==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
-    "@lerna/check-working-tree" "^3.8.1"
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/collect-updates" "^3.8.1"
-    "@lerna/command" "^3.8.1"
-    "@lerna/describe-ref" "^3.8.1"
-    "@lerna/log-packed" "^3.6.0"
-    "@lerna/npm-conf" "^3.7.0"
-    "@lerna/npm-dist-tag" "^3.7.1"
-    "@lerna/npm-publish" "^3.8.2"
-    "@lerna/output" "^3.6.0"
-    "@lerna/pack-directory" "^3.8.2"
-    "@lerna/prompt" "^3.6.0"
-    "@lerna/pulse-till-done" "^3.7.1"
-    "@lerna/run-lifecycle" "^3.8.2"
-    "@lerna/run-parallel-batches" "^3.0.0"
-    "@lerna/validation-error" "^3.6.0"
-    "@lerna/version" "^3.8.2"
+    "@lerna/batch-packages" "3.10.0"
+    "@lerna/check-working-tree" "3.10.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/collect-updates" "3.10.1"
+    "@lerna/command" "3.10.0"
+    "@lerna/describe-ref" "3.10.0"
+    "@lerna/log-packed" "3.6.0"
+    "@lerna/npm-conf" "3.7.0"
+    "@lerna/npm-dist-tag" "3.8.5"
+    "@lerna/npm-publish" "3.10.0"
+    "@lerna/output" "3.6.0"
+    "@lerna/pack-directory" "3.10.0"
+    "@lerna/prompt" "3.6.0"
+    "@lerna/pulse-till-done" "3.7.1"
+    "@lerna/run-lifecycle" "3.10.0"
+    "@lerna/run-parallel-batches" "3.0.0"
+    "@lerna/validation-error" "3.6.0"
+    "@lerna/version" "3.10.1"
     figgy-pudding "^3.5.1"
     fs-extra "^7.0.0"
     libnpm "^2.0.1"
@@ -466,14 +466,14 @@
     p-reduce "^1.0.0"
     semver "^5.5.0"
 
-"@lerna/pulse-till-done@^3.7.1":
+"@lerna/pulse-till-done@3.7.1":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@lerna/pulse-till-done/-/pulse-till-done-3.7.1.tgz#a9e55380fa18f6896a3e5b23621a4227adfb8f85"
   integrity sha512-MzpesZeW3Mc+CiAq4zUt9qTXI9uEBBKrubYHE36voQTSkHvu/Rox6YOvfUr+U7P6k8frFPeCgGpfMDTLhiqe6w==
   dependencies:
     libnpm "^2.0.1"
 
-"@lerna/resolve-symlink@^3.6.0":
+"@lerna/resolve-symlink@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz#985344796b704ff32afa923901e795e80741b86e"
   integrity sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==
@@ -482,26 +482,26 @@
     libnpm "^2.0.1"
     read-cmd-shim "^1.0.1"
 
-"@lerna/rimraf-dir@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.6.0.tgz#a02c4ad14d9a65c005021da79d545702b7085a74"
-  integrity sha512-2CfyWP1lqxDET+SfwGlLUfgqGF4vz9TYDrmb7Zi//g7IFCo899uU2vWOrEcdWTgbKE3Qgwwfk9c008w5MWUhog==
+"@lerna/rimraf-dir@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.10.0.tgz#2d9435054ab7bbc5519db0a2654c5d8cacd27f98"
+  integrity sha512-RSKSfxPURc58ERCD/PuzorR86lWEvIWNclXYGvIYM76yNGrWiDF44pGHQvB4J+Lxa5M+52ZtZC/eOC7A7YCH4g==
   dependencies:
-    "@lerna/child-process" "^3.3.0"
+    "@lerna/child-process" "3.3.0"
     libnpm "^2.0.1"
     path-exists "^3.0.0"
     rimraf "^2.6.2"
 
-"@lerna/run-lifecycle@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.8.2.tgz#fe97f771506e2351aa170ec75ef8e6d7e9b94509"
-  integrity sha512-V80nIoHpp0IL9WEaK8wz47SeqLSlI8DyNqVqUoG1DCeCGr6rdvRGD0FgHSKgRnZxk/SgP1Az/YBBtc5qnA+CzA==
+"@lerna/run-lifecycle@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.10.0.tgz#47a1988313c59a612ee7475e5accd3bd015cd9ae"
+  integrity sha512-awMdASrTetQKGgLMDlusLsw/QQumzrT055U31CfRdBV4U+kfWjVGIR25MKvXRJPG1yOH1Xf6HduyYgZVc8vgCA==
   dependencies:
-    "@lerna/npm-conf" "^3.7.0"
+    "@lerna/npm-conf" "3.7.0"
     figgy-pudding "^3.5.1"
     libnpm "^2.0.1"
 
-"@lerna/run-parallel-batches@^3.0.0":
+"@lerna/run-parallel-batches@3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz#468704934084c74991d3124d80607857d4dfa840"
   integrity sha512-Mj1ravlXF7AkkewKd9YFq9BtVrsStNrvVLedD/b2wIVbNqcxp8lS68vehXVOzoL/VWNEDotvqCQtyDBilCodGw==
@@ -509,71 +509,71 @@
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
-"@lerna/run@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.8.1.tgz#73fd74b90652a437cd11964f5c504bf11ee30957"
-  integrity sha512-EKJsdfuZYLr6QrEqOt7qteBIR/hZ/Fdk526fdVBtryaL5t1UESwaF741M65WWQMJnFOtJZI6n2tna5CX0n7xVQ==
+"@lerna/run@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.10.1.tgz#2b9eb2cff455de588a77a3d9b192bfe03ad866d7"
+  integrity sha512-g9YIcpk87Gok+zjicru/KsuZ1lcyuG5oERyAii3RSmpLaiwTh/SOSnxilrvDOYWwxYU5rPzvaCalkQI/i31Itw==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
-    "@lerna/command" "^3.8.1"
-    "@lerna/filter-options" "^3.8.1"
-    "@lerna/npm-run-script" "^3.6.0"
-    "@lerna/output" "^3.6.0"
-    "@lerna/run-parallel-batches" "^3.0.0"
-    "@lerna/timer" "^3.5.0"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/batch-packages" "3.10.0"
+    "@lerna/command" "3.10.0"
+    "@lerna/filter-options" "3.10.1"
+    "@lerna/npm-run-script" "3.10.0"
+    "@lerna/output" "3.6.0"
+    "@lerna/run-parallel-batches" "3.0.0"
+    "@lerna/timer" "3.5.0"
+    "@lerna/validation-error" "3.6.0"
     p-map "^1.2.0"
 
-"@lerna/symlink-binary@^3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.7.2.tgz#fedce89711ecfeb3d85fd7035199fab0436a793a"
-  integrity sha512-xS7DdBXNQgfgrhBe2Jz27+S65yxBfnl+Xi+grvlqoEGVk7b8kt2VcBtui/XgL6AAaTg6f9szj4LUnwC/oX6S1Q==
+"@lerna/symlink-binary@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.10.0.tgz#5acdde86dfd50c9270d7d2a93bade203cff41b3d"
+  integrity sha512-6mQsG+iVjBo8cD8s24O+YgFrwDyUGfUQbK4ryalAXFHI817Zd4xlI3tjg3W99whCt6rt6D0s1fpf8eslMN6dSw==
   dependencies:
-    "@lerna/create-symlink" "^3.6.0"
-    "@lerna/package" "^3.7.2"
+    "@lerna/create-symlink" "3.6.0"
+    "@lerna/package" "3.7.2"
     fs-extra "^7.0.0"
     p-map "^1.2.0"
 
-"@lerna/symlink-dependencies@^3.8.1":
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.8.1.tgz#890979f232beb9c4618a3b49d4ad11f567617642"
-  integrity sha512-MlXRTpB3Go/ubexxySngzg8PnItpPIxa0ydHMxvvw7s06g7ZsOOMOAx+F7AUPPr7bssdZ+gg5bfSq+J1HoINrg==
+"@lerna/symlink-dependencies@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.10.0.tgz#a20226e8e97af6a6bc4b416bfc28c0c5e3ba9ddd"
+  integrity sha512-vGpg5ydwGgQCuWNX5y7CRL38mGpuLhf1GRq9wMm7IGwnctEsdSNqvvE+LDgqtwEZASu5+vffYUkL0VlFXl8uWA==
   dependencies:
-    "@lerna/create-symlink" "^3.6.0"
-    "@lerna/resolve-symlink" "^3.6.0"
-    "@lerna/symlink-binary" "^3.7.2"
+    "@lerna/create-symlink" "3.6.0"
+    "@lerna/resolve-symlink" "3.6.0"
+    "@lerna/symlink-binary" "3.10.0"
     fs-extra "^7.0.0"
     p-finally "^1.0.0"
     p-map "^1.2.0"
     p-map-series "^1.0.0"
 
-"@lerna/timer@^3.5.0":
+"@lerna/timer@3.5.0":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@lerna/timer/-/timer-3.5.0.tgz#8dee6acf002c55de64678c66ef37ca52143f1b9b"
   integrity sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA==
 
-"@lerna/validation-error@^3.6.0":
+"@lerna/validation-error@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.6.0.tgz#550cf66bb2ef88edc02e36017b575a7a9100d5d8"
   integrity sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==
   dependencies:
     libnpm "^2.0.1"
 
-"@lerna/version@^3.8.2":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.8.2.tgz#4a44bb01a6a4121b46628fab0e2b9703429d73fb"
-  integrity sha512-TANvavzkyTcSVElsh8+zTZmsjzF6B0xuE9ldRdFKQaYAqmkkWNmf73BwLDZGisqEh45wnveiR9GeflSw4XI4iw==
+"@lerna/version@3.10.1":
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.10.1.tgz#7d33b1c086879cbdb7329264f28547e5444733e9"
+  integrity sha512-JrUz37xvvJFCC5M/xNaKMVOJ1Q8Y5d5TlR+3kZFn2qmWX87yYJJHNKzuBAxE5QU4oHjz3ED0qH1LXspSCjl3mg==
   dependencies:
-    "@lerna/batch-packages" "^3.6.0"
-    "@lerna/check-working-tree" "^3.8.1"
-    "@lerna/child-process" "^3.3.0"
-    "@lerna/collect-updates" "^3.8.1"
-    "@lerna/command" "^3.8.1"
-    "@lerna/conventional-commits" "^3.6.0"
-    "@lerna/output" "^3.6.0"
-    "@lerna/prompt" "^3.6.0"
-    "@lerna/run-lifecycle" "^3.8.2"
-    "@lerna/validation-error" "^3.6.0"
+    "@lerna/batch-packages" "3.10.0"
+    "@lerna/check-working-tree" "3.10.0"
+    "@lerna/child-process" "3.3.0"
+    "@lerna/collect-updates" "3.10.1"
+    "@lerna/command" "3.10.0"
+    "@lerna/conventional-commits" "3.10.0"
+    "@lerna/output" "3.6.0"
+    "@lerna/prompt" "3.6.0"
+    "@lerna/run-lifecycle" "3.10.0"
+    "@lerna/validation-error" "3.6.0"
     chalk "^2.3.1"
     dedent "^0.7.0"
     libnpm "^2.0.1"
@@ -586,7 +586,7 @@
     slash "^1.0.0"
     temp-write "^3.4.0"
 
-"@lerna/write-log-file@^3.6.0":
+"@lerna/write-log-file@3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@lerna/write-log-file/-/write-log-file-3.6.0.tgz#b8d5a7efc84fa93cbd67d724d11120343b2a849a"
   integrity sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==
@@ -2416,26 +2416,26 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-lerna@^3.6.0:
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.8.4.tgz#62cc2248e27bb62cf359fb2012a69884849c4012"
-  integrity sha512-bmFDfYiHhgaDndFT9o0HcQ7jNHi5OVF47Y8hWZWtVOpQuVDAYiAKXwtFCNoqgzIeZxsdGXI/VoW9aZ/IPHErMw==
+lerna@^3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.10.2.tgz#2c0568b8dc58286d984a5704bc449df3428851a0"
+  integrity sha512-6g2OzlrwWaZQQduL9xywJPEGJxbmC8jWD9QKZ8itkk7YIWEesbliD7buewnTxuIlsINSDrzYk7f/JDwq9EHIhg==
   dependencies:
-    "@lerna/add" "^3.8.2"
-    "@lerna/bootstrap" "^3.8.2"
-    "@lerna/changed" "^3.8.2"
-    "@lerna/clean" "^3.8.1"
-    "@lerna/cli" "^3.6.0"
-    "@lerna/create" "^3.8.1"
-    "@lerna/diff" "^3.8.1"
-    "@lerna/exec" "^3.8.1"
-    "@lerna/import" "^3.8.1"
-    "@lerna/init" "^3.8.1"
-    "@lerna/link" "^3.8.1"
-    "@lerna/list" "^3.8.1"
-    "@lerna/publish" "^3.8.4"
-    "@lerna/run" "^3.8.1"
-    "@lerna/version" "^3.8.2"
+    "@lerna/add" "3.10.2"
+    "@lerna/bootstrap" "3.10.2"
+    "@lerna/changed" "3.10.1"
+    "@lerna/clean" "3.10.1"
+    "@lerna/cli" "3.10.0"
+    "@lerna/create" "3.10.0"
+    "@lerna/diff" "3.10.0"
+    "@lerna/exec" "3.10.1"
+    "@lerna/import" "3.10.0"
+    "@lerna/init" "3.10.0"
+    "@lerna/link" "3.10.0"
+    "@lerna/list" "3.10.1"
+    "@lerna/publish" "3.10.1"
+    "@lerna/run" "3.10.1"
+    "@lerna/version" "3.10.1"
     import-local "^1.0.0"
     libnpm "^2.0.1"
 


### PR DESCRIPTION
`lerna` have been updated from `3.6.0` to `3.10.2`, after multiples tries from Greenkeeper.

Closes #10.